### PR TITLE
default.yml: remove west

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -11,7 +11,6 @@ manifest:
 
   projects:
     - name: zephyr
-    - name: west
     - name: net-tools
     - name: Kconfiglib
       path: ext/scripts/Kconfiglib


### PR DESCRIPTION
This is not part of the manifest anymore; we've special cased it so
that we don't have to put the manifest parser in the bootstrap/wrapper
script.

CC: @ulfalizer
CC: @tejlmand